### PR TITLE
Support notification based on cooldown of heater bed

### DIFF
--- a/docs/Telegram_config.md
+++ b/docs/Telegram_config.md
@@ -82,6 +82,12 @@ msg_paused="hey, i'm on break, please take a look"
 msg_error="hey, i had a error. please look it up"
 ```
 
+### bed cool down message
+
+```
+msg_bed_cooldown="hey, my heater bed is cool"
+```
+
 ### time in seconds to get an State update. to disable set it to 0
 
 ```
@@ -98,6 +104,12 @@ progress="0"
 
 ```
 z_high="0"
+```
+
+### Send a cooldown message when a heated bed has cooled to this temperatur. to disable set it to 0
+
+```
+bed_cooldown_temperature="0"
 ```
 
 ### with picture = 1, without picture = 0

--- a/example_config.sh
+++ b/example_config.sh
@@ -30,6 +30,8 @@ msg_complete="hey, i finished the last print now i am idling"
 msg_paused="hey, i'm on break, please take a look"
 # error message
 msg_error="hey, i had a error. please look it up"
+# bed cool down message
+msg_bed_cooldown="hey, my heater bed is cool"
 #
 # time in seconds to get an State update. to disable set it to 0
 time="0"
@@ -37,9 +39,11 @@ time="0"
 progress="0"
 # Z Hight in mm to get an State update. to disable set it to 0
 z_high="0"
-# with picture = 1, without picture = 0  
+# Send a cooldown message when a heated bed has cooled to this temperatur. to disable set it to 0
+bed_cooldown_temperature="0"
+# with picture = 1, without picture = 0
 picture="0"
-# with 5sec gif at state message = 1, without gif = 0  
+# with 5sec gif at state message = 1, without gif = 0
 gif="0"
 # your webcam snapshot link
 webcam="http://127.0.0.1:8080/?action=snapshot"
@@ -59,7 +63,7 @@ delay_end_msg="0"
 delay_pause_msg="0"
 #Led on link for picture
 led_on=""
-#Led on wait time before picture is taken (in seconds) 
+#Led on wait time before picture is taken (in seconds)
 led_on_delay="0"
 #Led off link for picture
 led_off=""

--- a/scripts/read_state.sh
+++ b/scripts/read_state.sh
@@ -41,7 +41,7 @@ if [ "$method" = "notify_status_update" ]; then
             if [ "$pause" = "0" ]; then
                 timelapse="$(curl -H "X-Api-Key: $api_key" -s "http://127.0.0.1:$port/printer/objects/query?gcode_macro%20TIMELAPSE_TAKE_FRAME")"
                 timelapse_pause=$(grep -oP '"is_paused": \K[^,]+'  <<< "$timelapse")
-                if [ $timelapse_pause = "true" ]; then
+                if [ "$timelapse_pause" = "true" ]; then
                   exit 1
                 else
                   sed -i "s/pause=.*$/pause="1"/g" $DIR_STATE/scripts/state_config.txt

--- a/scripts/telegram.sh
+++ b/scripts/telegram.sh
@@ -65,6 +65,10 @@ elif [ "$state_msg" = "6" ]; then
      -d text="${msg}" \
      -d chat_id=${chatid}
      msg=""
+
+elif [ "$state_msg" = "7" ]; then
+    msg="$msg_bed_cooldown"
+
 else
   if [ "$custom_picture" = "1" ]; then
     msg="$state_msg"

--- a/scripts/websocket-connection-telegram.py
+++ b/scripts/websocket-connection-telegram.py
@@ -19,7 +19,6 @@ prog_message = 0
 printer = 0
 z_message = 0
 progress_z = 0
-data = ""
 prog_message1 = 0
 z_message1 = 0
 z_message1 = float(z_message1)
@@ -42,8 +41,7 @@ def read_variables():
 
 
 def subscribe():
-    global data
-    data = {
+    return {
         "jsonrpc": "2.0",
         "method": "printer.objects.subscribe",
         "params": {
@@ -75,8 +73,7 @@ def on_message(ws, message):
         telegram_msg, b = telegram.split('"')
         os.system(f'bash {DIR1}/scripts/telegram.sh "{telegram_msg}" "1"')
     if "Klipper state: Ready" in message:
-        subscribe()
-        ws.send(json.dumps(data))
+        ws.send(json.dumps(subscribe()))
     if "print_stats" in message:
         if "state" in message:
             timelapse = requests.get(f'http://127.0.0.1:{port1}/printer/objects/query?gcode_macro%20TIMELAPSE_TAKE_FRAME', headers={"X-Api-Key":f'{api_key}'}).json()
@@ -156,12 +153,9 @@ def on_close(ws):
 def on_open(ws):
     def run(*args):
         for i in range(1):
-            start = 1
             time.sleep(1)
-            subscribe()
-            ws.send(json.dumps(data))
+            ws.send(json.dumps(subscribe()))
         time.sleep(5)
-        start = 0
     thread.start_new_thread(run, ())
 
 


### PR DESCRIPTION
Similar to #62, I am migrating from OctoPod and missed the bed cool down notification. I took a stab at implementing this notification. To assist with adding this notification, I refactored `on_message` to use a json parsed dictionary of the message instead of string parsing to differentiate the different messages. 