### PR TITLE
Update moonraker-telegram-requirements.txt

### DIFF
--- a/scripts/moonraker-telegram-requirements.txt
+++ b/scripts/moonraker-telegram-requirements.txt
@@ -2,4 +2,4 @@
 wheel==0.32.3
 websocket_client==0.58.0
 requests==2.21.0
-git+git://github.com/Raabi91/telepot.git#egg=telepot
+git+https://github.com/Raabi91/telepot.git#egg=telepot


### PR DESCRIPTION
During installation I got following error:
Collecting telepot
  Cloning git://github.com/Raabi91/telepot.git to /tmp/pip-install-_5u8kcjd/telepot_15928b7815df42da80f2f5ce236eb5d4
  Running command git clone --filter=blob:none --quiet git://github.com/Raabi91/telepot.git /tmp/pip-install-_5u8kcjd/telepot_15928b7815df42da80f2f5ce236eb5d4
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.